### PR TITLE
Install packages from a staging source during Pyxian build

### DIFF
--- a/stage0/00-configure-apt/files/pyxian.list
+++ b/stage0/00-configure-apt/files/pyxian.list
@@ -1,1 +1,2 @@
-deb http://pyxis-repo.s3.eu-north-1.amazonaws.com/pyxis-0.1/ pyxian main
+deb http://packages.renetec.io/pyxian/ buster main
+deb http://uncached.renetec.io/pyxian-staging/ buster main

--- a/stage2/06-set-prod-package-repo/00-run.sh
+++ b/stage2/06-set-prod-package-repo/00-run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+# Done with build-time package installations, remove staging repository
+sed -i '/pyxian-staging/d' "${ROOTFS_DIR}/etc/apt/sources.list.d/pyxian.list"


### PR DESCRIPTION
- Use "staged" from the package repo
- Switch to "main" after packages are installed