### PR TITLE
Fix splash screen and improve boot time

### DIFF
--- a/stage1/00-boot-files/files/cmdline.txt
+++ b/stage1/00-boot-files/files/cmdline.txt
@@ -1,1 +1,1 @@
-console=serial0,115200 console=tty3 root=ROOTDEV rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait quiet logo.nologo vt.global_cursor_default=0
+console=serial0,115200 console=tty3 root=ROOTDEV rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait quiet logo.nologo vt.global_cursor_default=0 loglevel=1

--- a/stage2/01-sys-tweaks/00-patches/07-resize-init.diff
+++ b/stage2/01-sys-tweaks/00-patches/07-resize-init.diff
@@ -1,5 +1,5 @@
 --- stage2.orig/rootfs/boot/cmdline.txt
 +++ stage2/rootfs/boot/cmdline.txt
 @@ -1 +1 @@
--console=serial0,115200 console=tty3 root=ROOTDEV rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait quiet logo.nologo vt.global_cursor_default=0
-+console=serial0,115200 console=tty3 root=ROOTDEV rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait quiet logo.nologo vt.global_cursor_default=0 init=/usr/lib/raspi-config/init_resize.sh
+-console=serial0,115200 console=tty3 root=ROOTDEV rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait quiet logo.nologo vt.global_cursor_default=0 loglevel=1
++console=serial0,115200 console=tty3 root=ROOTDEV rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait quiet logo.nologo vt.global_cursor_default=0 loglevel=1 init=/usr/lib/raspi-config/init_resize.sh

--- a/stage2/04-pngview/01-run.sh
+++ b/stage2/04-pngview/01-run.sh
@@ -2,7 +2,7 @@
 
 install -v -m 755 files/pngview                  "${ROOTFS_DIR}/usr/bin/"
 install -v -m 777 files/libraspidmx.so.1         "${ROOTFS_DIR}/usr/lib/"
-install -v -m 777 files/splashscreen.service     "${ROOTFS_DIR}/etc/systemd/system/"
+install -v -m 644 files/splashscreen.service     "${ROOTFS_DIR}/etc/systemd/system/"
 install -v -m 644 files/splash.png               "${ROOTFS_DIR}/opt/"
 
 on_chroot << EOF

--- a/stage2/04-pngview/files/splashscreen.service
+++ b/stage2/04-pngview/files/splashscreen.service
@@ -4,7 +4,7 @@ DefaultDependencies=no
 After=local-fs.target
 
 [Service]
-ExecStart=/usr/bin/pngview /opt/splash.png -b 0x346f
+ExecStart=/bin/bash -c "/usr/bin/pngview /opt/splash.png -b $(if [ $(cat /proc/device-tree/model | awk '{print $3}') == "4" ]; then echo 0x643f; else echo 0x346f; fi)"
 StandardInput=tty
 StandardOutput=tty
 


### PR DESCRIPTION
1. When we change the log level it reduces ower boot time.
2. Fix permission for the splash screen.
3. Provide a workaround for different background colors during splash screen.