### PR TITLE
Add TimeoutStopSec to pidpiod service.

### DIFF
--- a/stage2/05-inox/01-run.sh
+++ b/stage2/05-inox/01-run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+sudo sed -i '/\[Install\]/i TimeoutStopSec=1' "${ROOTFS_DIR}/lib/systemd/system/pigpiod.service"


### PR DESCRIPTION
Sometimes pidpiod service is holding reboot/shutdown.
As a solution add TimeoutStopSec which send SIGKILL
when time is ended.