### PR TITLE
Revert "Run splashscreen during basic target."

### DIFF
--- a/stage2/04-pngview/files/splashscreen.service
+++ b/stage2/04-pngview/files/splashscreen.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Splash screen
 DefaultDependencies=no
+After=local-fs.target
 
 [Service]
 ExecStart=/bin/bash -c "/usr/bin/pngview /opt/splash.png -b $(if [ $(cat /proc/device-tree/model | awk '{print $3}') == "4" ]; then echo 0x643f; else echo 0x346f; fi)"
@@ -8,5 +9,5 @@ StandardInput=tty
 StandardOutput=tty
 
 [Install]
-WantedBy=basic.target
+WantedBy=sysinit.target
 


### PR DESCRIPTION
This reverts commit b1101f00d69b11acf2d4eb2c8775d9e1513a44a7.

These changes broke splash screen behavior for raspberry pi 3
and 4 if HDMI is connected.